### PR TITLE
Fixes an issue where ws connection failure for big teams.

### DIFF
--- a/slackclient/server.py
+++ b/slackclient/server.py
@@ -74,9 +74,9 @@ class Server(object):
             login_data = reply.json()
             if login_data["ok"]:
                 self.ws_url = login_data['url']
+                self.connect_slack_websocket(self.ws_url)
                 if not reconnect:
                     self.parse_slack_login_data(login_data)
-                self.connect_slack_websocket(self.ws_url)
             else:
                 raise SlackLoginError
 


### PR DESCRIPTION
We have thousands and the WS URL was invalid by the time parse_slack_login_data parsed them all.  Got the idea from some code here on github but have tested it now (and I don't see it fixed in master).

###  Summary

Large teams shouldn't try to parse all the login data inbetween getting the WS URL and connecting to the WS URL (as there is a timeout for the valid period of that URL).  

This change is to move the connect to WS above the parse.  

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).